### PR TITLE
refactor: sort popular books by average rating

### DIFF
--- a/book-wise/src/pages/api/books/popular.ts
+++ b/book-wise/src/pages/api/books/popular.ts
@@ -6,7 +6,7 @@ export default async function handler(
   res: NextApiResponse,
 ) {
 
-  if(req.method !== "GET") return res.status(405).end()
+  if (req.method !== "GET") return res.status(405).end()
 
   const books = await prisma.book.findMany({
     orderBy: {
@@ -39,7 +39,9 @@ export default async function handler(
       ...bookInfo,
       avgRating: bookAvgRating?._avg.rate
     }
-  })
+  }).sort((a, b) =>
+    a.avgRating && b.avgRating ? b.avgRating - a.avgRating : 0
+  )
 
   return res.json({ books: booksWithAvgRating })
 }


### PR DESCRIPTION
Notei que quando é criado o array booksWithAvgRating não tem nenhuma ordenação e lá no frontend os livros populares são exibido desordenado pelo rate deles, achei meio estranho então resolvi acrescentar um sort para ordenar pelo rate

### antes

```js
books: [
  {
    "id": 1,
    "...",
    "avgRating": 2.5
  },
  {
    "id": 2,
    "...",
    "avgRating": 4.5
  },
  {
    "id": 3,
    "...",
    "avgRating": 1.5
  },
]
```

### depois com sort
```js
books: [
  {
    "id": 1,
    "...",
    "avgRating": 4.5
  },
  {
    "id": 2,
    "...",
    "avgRating": 2.5
  },
  {
    "id": 3,
    "...",
    "avgRating": 1.5
  },
]
```